### PR TITLE
use `ft_sdk::session` to track subscription status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ validator = "0.18"
 
 [dependencies.ft-sdk]
 version = "0.1.12"
-# path = "../../work/ft-sdk/ft-sdk/"
+path = "../../work/ft-sdk/ft-sdk/"
 features = ["sqlite-default", "auth-provider", "field-extractors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ validator = "0.18"
 
 
 [dependencies.ft-sdk]
-# version = "0.1.12"
-path = "../../work/ft-sdk/ft-sdk/"
+version = "0.1.13"
+# path = "../../work/ft-sdk/ft-sdk/"
 features = ["sqlite-default", "auth-provider", "field-extractors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ validator = "0.18"
 
 
 [dependencies.ft-sdk]
-version = "0.1.12"
+# version = "0.1.12"
 path = "../../work/ft-sdk/ft-sdk/"
 features = ["sqlite-default", "auth-provider", "field-extractors"]

--- a/README.md
+++ b/README.md
@@ -38,25 +38,18 @@ to this URL after the unsubscription is successful.
 
 This action also empties the `data -> subscription -> topics` set.
 
-### Set Tracker: `/t/?t=<encrypted/hashed uid>`
+### Set Tracker: `/set-tracker/?t=<encrypted/hashed uid>`
 
-This URL can be sent via mail or SMS. The `t` is unique to the user and is encrypted/hashed so that
-`user-id` can not be deduced from it by outsiders, but we can. In the browser the URL is opened, a tracker
-cookie is dropped, tracking the same user.
+Set a tracker cookie.
 
-This will create a new tracker (this is fastn behaviour) if tracker does not exists. It will assign
-the user corresponding to `t` to the tracker. If there was an existing user assigned to that tracker
-we will create a new tracker and assign the user to that tracker.
+The `t` is an encrypted string which contains the user id (as i64). If `t` is
+not provided, current logged in user id is used. If there is no logged in user,
+set an empty tracker cookie.
 
-Earlier we discussed a `/j/` url, which would do the cookie thing and redirect, but we are
-not doing that because:
-
-> There are few problems with this, one it introduces an extra redirect, then since it is 
-> setting cookie without showing any UI to user, there is no place to ask for consent, and 
-> finally Safari does not allow you to set cookie from a http redirect response.
-
-Based on these problems, the right solution seems to be we send the URL, with `t` query
-parameter attached, and show cookie banner to user, and do all this logic as an action.
+The tracker cookie should be also set:
+- on subscribe - set tracker id cookie
+- on log in - set tracker id cookie (in email-auth.wasm)
+- on cookie consent - set tracker id cookie
 
 ## Data
 

--- a/src/confirm_subscription.rs
+++ b/src/confirm_subscription.rs
@@ -45,7 +45,7 @@ fn confirm_subscription(
     let data = {
         let mut data = data;
 
-        data = mark_user_verified(data);
+        data = mark_subscription_verified(data);
 
         serde_json::to_string(&data)?
     };
@@ -76,7 +76,7 @@ fn get_name(user_data: &serde_json::Value) -> String {
         .unwrap_or_default()
 }
 
-pub(crate) fn mark_user_verified(mut user_data: serde_json::Value) -> serde_json::Value {
+pub(crate) fn mark_subscription_verified(mut user_data: serde_json::Value) -> serde_json::Value {
     match user_data
         .as_object_mut()
         .expect("data is always a json object")

--- a/src/is_subscribed.rs
+++ b/src/is_subscribed.rs
@@ -66,10 +66,6 @@ fn user_data_from_sid(
             OR fastn_user.id = json_extract(fastn_session.data, '$.subscription_uid')
             WHERE
                 fastn_session.id = $1
-                AND (
-                    fastn_user.id = fastn_session.uid
-                    OR fastn_user.id = json_extract(fastn_session.data, '$.subscription_uid')
-                )
             LIMIT 1;
             "#,
         )

--- a/src/is_subscribed.rs
+++ b/src/is_subscribed.rs
@@ -47,31 +47,36 @@ fn check_if_subscribed(topic: Option<String>, user_data: serde_json::Value) -> b
     subscribed && confirmed
 }
 
+/// try to get user data from the session's uid or session's data->'subscription_uid'
 fn user_data_from_sid(
     ft_sdk::Cookie(user_id_from_session): ft_sdk::Cookie<{ ft_sdk::auth::SESSION_KEY }>,
     conn: &mut ft_sdk::Connection,
 ) -> Result<serde_json::Value, ft_sdk::Error> {
     use diesel::prelude::*;
 
-    let query;
-    if user_id_from_session.is_some() {
+    let query = if user_id_from_session.is_some() {
         let user_id = user_id_from_session.unwrap();
-        query = diesel::sql_query(
+        diesel::sql_query(
             r#"
             SELECT
                 fastn_user.data as data
             FROM fastn_user
             JOIN fastn_session
+            ON fastn_user.id = fastn_session.uid 
+            OR fastn_user.id = json_extract(fastn_session.data, '$.subscription_uid')
             WHERE
                 fastn_session.id = $1
-                AND fastn_user.id = fastn_session.uid
+                AND (
+                    fastn_user.id = fastn_session.uid
+                    OR fastn_user.id = json_extract(fastn_session.data, '$.subscription_uid')
+                )
             LIMIT 1;
             "#,
         )
-        .bind::<diesel::sql_types::Text, _>(user_id);
+        .bind::<diesel::sql_types::Text, _>(user_id)
     } else {
         return Err(ft_sdk::single_error("user_id", "user_id is required").into());
-    }
+    };
 
     #[derive(diesel::QueryableByName)]
     #[diesel(table_name = ft_sdk::auth::fastn_user)]

--- a/src/is_subscribed.rs
+++ b/src/is_subscribed.rs
@@ -9,10 +9,9 @@
 fn is_subscribed(
     ft_sdk::Query(topic): ft_sdk::Query<"topic", Option<String>>,
     sid: ft_sdk::Cookie<{ ft_sdk::auth::SESSION_KEY }>,
-    tid: ft_sdk::Cookie<"fastn-tid">,
     mut conn: ft_sdk::Connection,
 ) -> ft_sdk::data::Result {
-    let data = match user_data_from_sid_or_tid(sid, tid, &mut conn) {
+    let data = match user_data_from_sid(sid, &mut conn) {
         Ok(d) => d,
         Err(_) => return ft_sdk::data::json(serde_json::json!({ "subscribed": false })),
     };
@@ -22,32 +21,34 @@ fn is_subscribed(
     ft_sdk::data::json(serde_json::json!({ "subscribed": subscribed }))
 }
 
+/// user has subscribed and confirmed subscription by clicking on the double opt-in email
 fn check_if_subscribed(topic: Option<String>, user_data: serde_json::Value) -> bool {
+    let sub = user_data
+        .as_object()
+        .and_then(|v| v.get("subscription"))
+        .and_then(|v| v.as_object());
+
     let subscribed = if let Some(topic) = topic {
-        user_data
-            .as_object()
-            .and_then(|v| v.get("subscription"))
-            .and_then(|v| v.as_object())
-            .and_then(|v| v.get("topics"))
+        sub.and_then(|v| v.get("topics"))
             .and_then(|v| v.as_array())
             .map(|topics| topics.iter().any(|t| t.as_str() == Some(&topic)))
             .unwrap_or_default()
     } else {
-        user_data
-            .as_object()
-            .and_then(|v| v.get("subscription"))
-            .and_then(|v| v.as_object())
-            .and_then(|v| v.get("subscribed"))
+        sub.and_then(|v| v.get("subscribed"))
             .and_then(|v| v.as_bool())
             .unwrap_or_default()
     };
 
-    subscribed
+    let confirmed = sub
+        .and_then(|v| v.get("confirmed"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or_default();
+
+    subscribed && confirmed
 }
 
-fn user_data_from_sid_or_tid(
+fn user_data_from_sid(
     ft_sdk::Cookie(user_id_from_session): ft_sdk::Cookie<{ ft_sdk::auth::SESSION_KEY }>,
-    ft_sdk::Cookie(user_id_from_tracker): ft_sdk::Cookie<"fastn-tid">,
     conn: &mut ft_sdk::Connection,
 ) -> Result<serde_json::Value, ft_sdk::Error> {
     use diesel::prelude::*;
@@ -64,21 +65,6 @@ fn user_data_from_sid_or_tid(
             WHERE
                 fastn_session.id = $1
                 AND fastn_user.id = fastn_session.uid
-            LIMIT 1;
-            "#,
-        )
-        .bind::<diesel::sql_types::Text, _>(user_id);
-    } else if user_id_from_tracker.is_some() {
-        let user_id = user_id_from_tracker.unwrap();
-        query = diesel::sql_query(
-            r#"
-            SELECT
-                fastn_user.data as data
-            FROM fastn_user
-            JOIN fastn_tracker
-            WHERE
-                fastn_tracker.id = $1
-                AND fastn_user.id = fastn_tracker.uid
             LIMIT 1;
             "#,
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,19 @@ pub const SUBSCRIPTION_PROVIDER_ID: &str = "subscription";
 pub const DEFAULT_REDIRECT_ROUTE: &str = "/";
 
 pub fn tracker_cookie(tid: &str, host: ft_sdk::Host) -> Result<http::HeaderValue, ft_sdk::Error> {
-    let cookie = cookie::Cookie::build((ft_sdk::tracker::TRACKER_KEY, tid))
+    let cookie = cookie::Cookie::build((ft_sdk::session::TRACKER_KEY, tid))
+        .domain(host.without_port())
+        .path("/")
+        .max_age(cookie::time::Duration::seconds(34560000))
+        .same_site(cookie::SameSite::Strict)
+        .build();
+
+    Ok(http::HeaderValue::from_str(cookie.to_string().as_str())?)
+}
+
+pub fn session_cookie(sid: &str, host: ft_sdk::Host) -> Result<http::HeaderValue, ft_sdk::Error> {
+    // DO NOT CHANGE THINGS HERE, consult logout code in fastn.
+    let cookie = cookie::Cookie::build((ft_sdk::auth::SESSION_KEY, sid))
         .domain(host.without_port())
         .path("/")
         .max_age(cookie::time::Duration::seconds(34560000))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod set_tracker;
 mod unsubscribe;
 mod welcome_email_templ; // set-tracker
 
-pub(crate) use confirm_subscription::mark_user_verified;
+pub(crate) use confirm_subscription::mark_subscription_verified;
 pub(crate) use confirm_subscription::send_welcome_email;
 pub(crate) use subscribe::email_from_address_from_env;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod confirm_email_templ;
 mod confirm_subscription;
 mod is_subscribed;
 mod subscribe;
-mod t;
+mod set_tracker;
 mod unsubscribe;
 mod welcome_email_templ; // set-tracker
 
@@ -14,12 +14,10 @@ pub(crate) use subscribe::email_from_address_from_env;
 
 pub const EMAIL_PROVIDER_ID: &str = "email";
 pub const SUBSCRIPTION_PROVIDER_ID: &str = "subscription";
-pub const TRACKER: &str = "fastn_tid";
 pub const DEFAULT_REDIRECT_ROUTE: &str = "/";
 
 pub fn tracker_cookie(tid: &str, host: ft_sdk::Host) -> Result<http::HeaderValue, ft_sdk::Error> {
-    // DO NOT CHANGE THINGS HERE, consult logout code in fastn.
-    let cookie = cookie::Cookie::build((TRACKER, tid))
+    let cookie = cookie::Cookie::build((ft_sdk::tracker::TRACKER_KEY, tid))
         .domain(host.without_port())
         .path("/")
         .max_age(cookie::time::Duration::seconds(34560000))

--- a/src/set_tracker.rs
+++ b/src/set_tracker.rs
@@ -1,0 +1,54 @@
+/// ### Set Tracker: `/set-tracker/?t=<encrypted/hashed uid>`
+/// create a tracker cookie with the user_id decrypted from `t`
+///
+// if there's a ?t then set session to tracking user id
+// if there's no ?t and the sid.0 is None then create a new session
+#[ft_sdk::processor]
+fn set_tracker(
+    mut conn: ft_sdk::Connection,
+    // t is the encrypted user_id (i64)
+    ft_sdk::Query(t): ft_sdk::Query<"t", Option<String>>,
+    sid: ft_sdk::Cookie<{ ft_sdk::auth::SESSION_KEY }>,
+    host: ft_sdk::Host,
+) -> ft_sdk::processor::Result {
+    // set the tracking cookie
+    let session_id = match t {
+        Some(t) => Some(create_session_using_t(t, &mut conn)?),
+        None => {
+            if sid.0.is_none() {
+                Some(ft_sdk::session::SessionID::new(&mut conn, None, None)?)
+            } else {
+                // session is already set, do nothing
+                None
+            }
+        }
+    };
+
+    let mut resp = ft_sdk::processor::json(serde_json::json!({ "success": true }))?;
+
+    if let Some(session_id) = session_id {
+        resp = resp.with_cookie(subscription::session_cookie(&session_id.0, host.clone())?);
+    }
+
+    resp = resp.with_cookie(subscription::tracker_cookie(
+        &ft_sdk::utils::uuid_v8(),
+        host,
+    )?);
+
+    Ok(resp)
+}
+
+/// create tracker entry using the user id decrypted and parsed from `t`
+/// `t` is the encrypted user_id (i64)
+fn create_session_using_t(
+    t: String,
+    conn: &mut ft_sdk::Connection,
+) -> Result<ft_sdk::session::SessionID, ft_sdk::Error> {
+    let user_id: ft_sdk::PlainText =
+        ft_sdk::EncryptedString::from_already_encrypted_string(t).try_into()?;
+
+    let user_id = user_id.to_string().parse::<i64>()?;
+    let user_id = ft_sdk::auth::UserId(user_id);
+
+    Ok(ft_sdk::session::SessionID::new(conn, Some(user_id), None)?)
+}

--- a/src/set_tracker.rs
+++ b/src/set_tracker.rs
@@ -16,7 +16,8 @@ fn set_tracker(
         Some(t) => Some(create_session_using_t(t, &mut conn)?),
         None => {
             if sid.0.is_none() {
-                Some(ft_sdk::session::SessionID::new(&mut conn, None, None)?)
+                // create empty session
+                Some(ft_sdk::SessionID::create(&mut conn, None, None)?)
             } else {
                 // session is already set, do nothing
                 None
@@ -43,12 +44,12 @@ fn set_tracker(
 fn create_session_using_t(
     t: String,
     conn: &mut ft_sdk::Connection,
-) -> Result<ft_sdk::session::SessionID, ft_sdk::Error> {
+) -> Result<ft_sdk::SessionID, ft_sdk::Error> {
     let user_id: ft_sdk::PlainText =
         ft_sdk::EncryptedString::from_already_encrypted_string(t).try_into()?;
 
     let user_id = user_id.to_string().parse::<i64>()?;
-    let user_id = ft_sdk::auth::UserId(user_id);
+    let session_data = serde_json::json!({ "subscription_uid": user_id });
 
-    Ok(ft_sdk::session::SessionID::new(conn, Some(user_id), None)?)
+    ft_sdk::SessionID::create(conn, None, Some(session_data))
 }

--- a/src/subscribe.rs
+++ b/src/subscribe.rs
@@ -66,7 +66,12 @@ fn subscribe(
 
     let next = if is_authenticated { on_confirm } else { next };
 
-    ft_sdk::form::redirect(next.unwrap_or_else(|| "/thank-you/".to_string()))
+    let tracker_id = ft_sdk::tracker::create_tracker(&mut conn, Some(user_id.0))?;
+
+    Ok(
+        ft_sdk::form::redirect(next.unwrap_or_else(|| "/thank-you/".to_string()))?
+            .with_cookie(subscription::tracker_cookie(tracker_id.0.as_str(), host)?),
+    )
 }
 
 struct Subscriber {

--- a/src/t.rs
+++ b/src/t.rs
@@ -1,6 +1,0 @@
-#[ft_sdk::processor]
-fn test_route() -> ft_sdk::processor::Result {
-    ft_sdk::processor::json(serde_json::json!({
-        "ok": true,
-    }))
-}


### PR DESCRIPTION
We could not track the subscription status of anonymous users (users that have not logged in). For this, we now use the `ft_sdk::session` to store the subscriber's id as `subscription_uid`. This is later used in `/is-subscribed/` handler to get the subscription status.

A `/set-tracker/` route is also added which is useful in email campaigns where we want to update the session to contain the user id coming from links inside of emails (encrypted of course).